### PR TITLE
Move site name and experiment label to manifest

### DIFF
--- a/simulations/manifest.py
+++ b/simulations/manifest.py
@@ -3,28 +3,26 @@
 from pathlib import Path
 import os
 
-# ========================================================
-"""
-This section contains the most important parameters that you may want to change before running the snakemake workflow.
-use_local_eradication: set to 0 to run workflow using the Eradication and schema currently under download_folder.
-                       set to 1 to get Eradicaiton and schema from emod_malaria and unzip them to download_folder.
-singularity_id: the AC id for singularity image that the simulation will be run with.
-                Set it to None if you don't want to run with any singularity image.
-"""
-use_local_eradication = 1
-singularity_id = "8df53802-53f3-ec11-a9f9-b88303911bc1"
-# ========================================================
+VENV_PATH = '/home/tmh6260/my_environments/pytorch_test'
+SITE='Nanoro'
+EXPERIMENT_LABEL='sample_experiment'
 
 CURRENT_DIR = Path(__file__).resolve().parent
 PROJECT_DIR = CURRENT_DIR.parent
-DOWNLOAD_DIR = CURRENT_DIR / "download" / "bin_230614_PT"
 
+job_directory = PROJECT_DIR / 'experiments'
+os.makedirs(job_directory, exist_ok=True)
+
+input_files_path = PROJECT_DIR / "simulation_inputs"
+simulation_coordinator_path = input_files_path / "simulation_coordinator.csv"
+calibration_coordinator_path = input_files_path / "calibration_coordinator.csv"
+
+DOWNLOAD_DIR = CURRENT_DIR / "download" / "bin_230614_PT"
 # The script is going to use this to store the downloaded schema file. Create 'download' directory or change to your preferred (existing) location.
 schema_file = DOWNLOAD_DIR / "schema.json"
 # The script is going to use this to store the downloaded Eradication binary. Create 'download' directory or change to your preferred (existing) location.
 eradication_path = DOWNLOAD_DIR / "Eradication"
 plugins_folder = DOWNLOAD_DIR / "reporter_plugins"
-
 # Create 'Assets' directory or change to a path you prefer. idmtools will upload files found here.
 assets_input_dir = CURRENT_DIR / "Assets"
 # analyzed_ouptut_path = PROJECT_DIR / "EMOD_validation_recalibration" / "simulation_output"
@@ -37,15 +35,13 @@ sif_id = comps_id_folder / 'sif.id'
 simulation_input_filepath = PROJECT_DIR / "simulation_inputs" #CURRENT_DIR / "output"
 simulation_output_filepath = PROJECT_DIR / "simulation_outputs" #CURRENT_DIR / "output"
 benchmark_simulation_filepath = PROJECT_DIR / "simulation_outputs" #CURRENT_DIR / "output"
-input_files_path = PROJECT_DIR / "simulation_inputs"
 base_script_plot_filepath = PROJECT_DIR / "create_plots"
 base_reference_filepath = PROJECT_DIR / "reference_datasets"
 plot_output_filepath = PROJECT_DIR / "report" / "_plots"
 python_plot_output_filepath = PROJECT_DIR / "report" / "_plots_Python"
 
 
-# TODO: remove following lines
-simulation_coordinator_path = input_files_path / "simulation_coordinator.csv"
+
 sweep_sim_coordinator_path = input_files_path / "sweep_sim_coordinator.csv"
 
 my_ep4_assets = None
@@ -60,7 +56,16 @@ node_group = 'idm_abcd'
 # This is the path to the sisf image used to run EMOD
 SIF_PATH = "--bind /projects /projects/b1139/images/dtk_run_rocky_py39.sif"
 
-job_directory = PROJECT_DIR / 'experiments'
-os.makedirs(job_directory, exist_ok=True)
+# ========================================================
+"""
+This section contains the most important parameters that you may want to change before running the snakemake workflow.
+use_local_eradication: set to 0 to run workflow using the Eradication and schema currently under download_folder.
+                       set to 1 to get Eradicaiton and schema from emod_malaria and unzip them to download_folder.
+singularity_id: the AC id for singularity image that the simulation will be run with.
+                Set it to None if you don't want to run with any singularity image.
+"""
+use_local_eradication = 1
+singularity_id = "8df53802-53f3-ec11-a9f9-b88303911bc1"
+# ========================================================
 
-VENV_PATH = '/home/tmh6260/my_environments/pytorch_test'
+

--- a/simulations/run_calib.py
+++ b/simulations/run_calib.py
@@ -28,14 +28,14 @@ from run_full_comparison import plot_allAge_prevalence,plot_incidence,compute_sc
 
 ####################################
 # Experiment details - this is the only section you need to edit with the script
-Site="Nanoro"
-exp_label = "test_pfpr_short"
+Site=manifest.SITE
+exp_label = manifest.EXPERIMENT_LABEL
 ####################################
 
 output_dir = f"output/{exp_label}"
 best_dir = f"output/{exp_label}" 
 
-calib_coord = pd.read_csv(os.path.join(manifest.input_files_path,"calibration_coordinator.csv"))
+calib_coord = pd.read_csv(manifest.calibration_coordinator_path)
 
 # Botorch details
 calib_coord = calib_coord.set_index("site")


### PR DESCRIPTION
tested by TH @ /projects/b1139/environment_calibration/simulations/output/sample_experiment

variables users need to supply are moved toward the top of the manifest.py file
- `VENV_PATH`
- `SITE`
- `EXPERIMENT_LABEL`

